### PR TITLE
Add canvas-core geometry utils package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .next
 out
 .DS_Store
+dist

--- a/packages/canvas-core/README.md
+++ b/packages/canvas-core/README.md
@@ -1,0 +1,15 @@
+# @madts/canvas-core
+
+Utility library for geometric calculations used by Math-Playground.
+
+## Usage
+
+```ts
+import { Point, distance, areaRectangle } from '@madts/canvas-core';
+
+const a: Point = { x: 0, y: 0 };
+const b: Point = { x: 3, y: 4 };
+
+distance(a, b); // 5
+areaRectangle(2, 4); // 8
+```

--- a/packages/canvas-core/package.json
+++ b/packages/canvas-core/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@madts/canvas-core",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/canvas-core/src/index.ts
+++ b/packages/canvas-core/src/index.ts
@@ -1,0 +1,67 @@
+export type Point = {
+  x: number;
+  y: number;
+};
+
+/**
+ * Calculate Euclidean distance between two points.
+ */
+export function distance(a: Point, b: Point): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.hypot(dx, dy);
+}
+
+/**
+ * Area of a rectangle.
+ */
+export function areaRectangle(width: number, height: number): number {
+  return width * height;
+}
+
+/**
+ * Perimeter of a rectangle.
+ */
+export function perimeterRectangle(width: number, height: number): number {
+  return 2 * (width + height);
+}
+
+/**
+ * Area of a circle.
+ */
+export function areaCircle(radius: number): number {
+  return Math.PI * radius * radius;
+}
+
+/**
+ * Circumference of a circle.
+ */
+export function circumference(radius: number): number {
+  return 2 * Math.PI * radius;
+}
+
+/**
+ * Compute polygon area using the shoelace formula.
+ */
+export function polygonArea(points: Point[]): number {
+  let area = 0;
+  const n = points.length;
+  for (let i = 0; i < n; i += 1) {
+    const { x: x1, y: y1 } = points[i];
+    const { x: x2, y: y2 } = points[(i + 1) % n];
+    area += x1 * y2 - x2 * y1;
+  }
+  return Math.abs(area) / 2;
+}
+
+/**
+ * Compute polygon perimeter by summing edge lengths.
+ */
+export function polygonPerimeter(points: Point[]): number {
+  let peri = 0;
+  const n = points.length;
+  for (let i = 0; i < n; i += 1) {
+    peri += distance(points[i], points[(i + 1) % n]);
+  }
+  return peri;
+}

--- a/packages/canvas-core/tsconfig.json
+++ b/packages/canvas-core/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- create `packages/canvas-core` package
- add TypeScript helpers for points, distance, area and perimeter calculations
- update `.gitignore`

## Testing
- `pnpm install` *(fails to lint due to missing peer deps)*
- `pnpm lint` *(fails: several eslint rule errors)*
- `pnpm --filter @madts/canvas-core build`


------
https://chatgpt.com/codex/tasks/task_e_68488381af908323a1fcf613a1e6d30c