### PR TITLE
Refactor Hello Shapes into demos package

### DIFF
--- a/apps/site/app/demo/hello-shapes/page.tsx
+++ b/apps/site/app/demo/hello-shapes/page.tsx
@@ -1,5 +1,5 @@
 import Whiteboard from '../../components/Whiteboard'
-import SquareBuilder from './SquareBuilder'
+import SquareBuilder from '@madts/demos/area-perimeter'
 
 export default function HelloShapesPage() {
   return (

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@madts/demos",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./area-perimeter": {
+      "import": "./dist/area-perimeter/index.js",
+      "types": "./dist/area-perimeter/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "dependencies": {
+    "@madts/ui-kit": "workspace:*",
+    "@madts/canvas-core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/demos/src/area-perimeter/index.tsx
+++ b/packages/demos/src/area-perimeter/index.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import React, { useState, useRef } from 'react'
+import * as React from 'react'
+import { useState, useRef } from 'react'
 import { areaRectangle, perimeterRectangle } from '@madts/canvas-core'
 import { InfoPanel } from '@madts/ui-kit'
 
-export default function SquareBuilder() {
+export default function SquareBuilder(): React.ReactElement {
   const [side, setSide] = useState(100)
   const [position, setPosition] = useState({ x: 50, y: 50 })
   const [dragging, setDragging] = useState(false)
@@ -13,7 +14,7 @@ export default function SquareBuilder() {
   const startOffset = useRef({ x: 0, y: 0 })
   const startSide = useRef(100)
 
-  function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
+  function onPointerDown(e: React.PointerEvent<HTMLDivElement>): void {
     e.preventDefault()
     setDragging(true)
     startPos.current = { x: e.clientX, y: e.clientY }
@@ -21,19 +22,19 @@ export default function SquareBuilder() {
     ;(e.target as Element).setPointerCapture(e.pointerId)
   }
 
-  function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
+  function onPointerMove(e: React.PointerEvent<HTMLDivElement>): void {
     if (!dragging) return
     const dx = e.clientX - startPos.current.x
     const dy = e.clientY - startPos.current.y
     setPosition({ x: startOffset.current.x + dx, y: startOffset.current.y + dy })
   }
 
-  function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
+  function onPointerUp(e: React.PointerEvent<HTMLDivElement>): void {
     setDragging(false)
     ;(e.target as Element).releasePointerCapture(e.pointerId)
   }
 
-  function onResizeDown(e: React.PointerEvent<HTMLDivElement>) {
+  function onResizeDown(e: React.PointerEvent<HTMLDivElement>): void {
     e.stopPropagation()
     setResizing(true)
     startPos.current = { x: e.clientX, y: e.clientY }
@@ -41,7 +42,7 @@ export default function SquareBuilder() {
     ;(e.target as Element).setPointerCapture(e.pointerId)
   }
 
-  function onResizeMove(e: React.PointerEvent<HTMLDivElement>) {
+  function onResizeMove(e: React.PointerEvent<HTMLDivElement>): void {
     if (!resizing) return
     const dx = e.clientX - startPos.current.x
     const dy = e.clientY - startPos.current.y
@@ -49,7 +50,7 @@ export default function SquareBuilder() {
     setSide(Math.max(10, startSide.current + delta))
   }
 
-  function onResizeUp(e: React.PointerEvent<HTMLDivElement>) {
+  function onResizeUp(e: React.PointerEvent<HTMLDivElement>): void {
     setResizing(false)
     ;(e.target as Element).releasePointerCapture(e.pointerId)
   }

--- a/packages/demos/src/index.ts
+++ b/packages/demos/src/index.ts
@@ -1,0 +1,1 @@
+export { default as AreaPerimeter } from './area-perimeter';

--- a/packages/demos/tsconfig.json
+++ b/packages/demos/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react",
+    "types": ["react"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- move SquareBuilder demo to `packages/demos`
- export demo from new `@madts/demos` package
- update Hello Shapes page to use the shared component

## Testing
- `pnpm lint` *(fails: parserOptions.project errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849a84e716c832387a22738dc7581ca