### PR TITLE
Add Vercel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ math-playground/
 3. **Open** <http://localhost:3000> and drag out a *Square Builder*—area & perimeter update live.
 4. **Deploy**
    * Click the **Vercel** button above and follow the prompts (free tier OK).
+   * In your repository settings add `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID` as
+     secrets so GitHub Actions can trigger preview and production deployments.
 
 ---
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "rootDirectory": "apps/site",
+  "buildCommand": "pnpm --filter site build",
+  "devCommand": "pnpm --filter site dev",
+  "installCommand": "pnpm install",
+  "outputDirectory": "apps/site/.next",
+  "framework": "nextjs",
+  "preview": {
+    "env": {
+      "NEXT_PUBLIC_APP_ENV": "preview"
+    }
+  },
+  "production": {
+    "env": {
+      "NEXT_PUBLIC_APP_ENV": "production"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to build the Next.js site
- document `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID` secrets in README

## Testing
- `pnpm test`
- `pnpm e2e` *(fails: browserType.launch executable not found)*
- `pnpm lint` *(fails: ESLint parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849c527d25083239ca429261efe98d1