### PR TITLE
Add turbo lesson generator

### DIFF
--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,0 +1,44 @@
+import type { PlopTypes } from '@turbo/gen';
+
+export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  plop.setGenerator('lesson', {
+    description: 'Scaffold a new demo lesson',
+    prompts: [
+      {
+        type: 'input',
+        name: 'slug',
+        message: 'Lesson slug (kebab-case):',
+      },
+    ],
+    actions: [
+      {
+        type: 'add',
+        path: 'packages/demos/{{kebabCase slug}}/index.mdx',
+        templateFile: 'turbo/generators/templates/index.mdx.hbs',
+      },
+      {
+        type: 'add',
+        path: 'packages/demos/src/{{kebabCase slug}}/index.tsx',
+        templateFile: 'turbo/generators/templates/component.tsx.hbs',
+      },
+      {
+        type: 'add',
+        path: 'packages/demos/src/{{kebabCase slug}}.test.tsx',
+        templateFile: 'turbo/generators/templates/test.tsx.hbs',
+      },
+      {
+        type: 'append',
+        path: 'packages/demos/src/index.ts',
+        template:
+          "export { default as {{pascalCase slug}} } from './{{kebabCase slug}}';",
+      },
+      {
+        type: 'append',
+        path: 'packages/demos/package.json',
+        pattern: /"exports": {(?<insertion>)/g,
+        template:
+          '    "./{{kebabCase slug}}": { "import": "./dist/{{kebabCase slug}}/index.js", "types": "./dist/{{kebabCase slug}}/index.d.ts" },',
+      },
+    ],
+  });
+}

--- a/turbo/generators/templates/component.tsx.hbs
+++ b/turbo/generators/templates/component.tsx.hbs
@@ -1,0 +1,6 @@
+'use client'
+import * as React from 'react'
+
+export default function {{ pascalCase slug }}(): React.ReactElement {
+  return <div>{{ pascalCase slug }} demo placeholder</div>
+}

--- a/turbo/generators/templates/index.mdx.hbs
+++ b/turbo/generators/templates/index.mdx.hbs
@@ -1,0 +1,5 @@
+import Component from '../src/{{kebabCase slug}}'
+
+# {{ properCase slug }}
+
+<Component />

--- a/turbo/generators/templates/test.tsx.hbs
+++ b/turbo/generators/templates/test.tsx.hbs
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+import {{ pascalCase slug }} from './{{kebabCase slug}}'
+
+describe('{{ pascalCase slug }}', () => {
+  it('renders', () => {
+    expect(renderToString(<{{ pascalCase slug }} />)).toContain('{{ pascalCase slug }} demo placeholder')
+  })
+})


### PR DESCRIPTION
## Summary
- implement a `turbo` generator for `lesson`
- templates scaffold MDX, React component, and unit test

## Testing
- `pnpm test`
- `pnpm e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca8c0f188323abf1976ab91075e9