### PR TITLE
Add transformations lesson

### DIFF
--- a/apps/site/app/demo/page.tsx
+++ b/apps/site/app/demo/page.tsx
@@ -3,7 +3,10 @@
 import Link from 'next/link'
 import { useProgress } from '@madts/canvas-core'
 
-const lessons = [{ slug: 'hello-shapes', title: 'Hello Shapes' }]
+const lessons = [
+  { slug: 'hello-shapes', title: 'Hello Shapes' },
+  { slug: 'transformations', title: 'Transformations' },
+]
 
 export default function DemoList() {
   const { isCompleted } = useProgress()

--- a/apps/site/app/demo/transformations/page.tsx
+++ b/apps/site/app/demo/transformations/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+import TriangleTransform from '@madts/demos/transformations'
+import { useProgress } from '@madts/canvas-core'
+
+export default function TransformationsPage() {
+  const { markComplete } = useProgress()
+  useEffect(() => {
+    markComplete('transformations')
+  }, [markComplete])
+
+  return (
+    <main className="flex min-h-screen w-screen flex-col items-center gap-4 p-4">
+      <div className="relative h-[80vh] w-full border">
+        <TriangleTransform />
+      </div>
+    </main>
+  )
+}

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -3,7 +3,10 @@
 import Link from "next/link";
 import { useProgress } from "@madts/canvas-core";
 
-const lessons = [{ slug: "hello-shapes", title: "Hello Shapes" }];
+const lessons = [
+  { slug: "hello-shapes", title: "Hello Shapes" },
+  { slug: "transformations", title: "Transformations" },
+];
 
 export default function Home() {
   const { isCompleted } = useProgress();

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -11,6 +11,10 @@
     "./area-perimeter": {
       "import": "./dist/area-perimeter/index.js",
       "types": "./dist/area-perimeter/index.d.ts"
+    },
+    "./transformations": {
+      "import": "./dist/transformations/index.js",
+      "types": "./dist/transformations/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/demos/src/index.ts
+++ b/packages/demos/src/index.ts
@@ -1,1 +1,2 @@
 export { default as AreaPerimeter } from './area-perimeter';
+export { default as Transformations } from './transformations';

--- a/packages/demos/src/transformations/index.tsx
+++ b/packages/demos/src/transformations/index.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import React, { useState, useRef } from 'react'
+import { InfoPanel } from '@madts/ui-kit'
+
+export type Point = { x: number; y: number }
+
+const initial: Point[] = [
+  { x: 100, y: 100 },
+  { x: 200, y: 100 },
+  { x: 150, y: 200 },
+]
+
+function centroid(pts: Point[]): Point {
+  const c = pts.reduce((acc, p) => ({ x: acc.x + p.x, y: acc.y + p.y }), { x: 0, y: 0 })
+  return { x: c.x / pts.length, y: c.y / pts.length }
+}
+
+function transform(points: Point[]): { dx: number; dy: number; angle: number; scale: number } {
+  const c0 = centroid(initial)
+  const c1 = centroid(points)
+  const dx = c1.x - c0.x
+  const dy = c1.y - c0.y
+  const v0 = { x: initial[1].x - initial[0].x, y: initial[1].y - initial[0].y }
+  const v1 = { x: points[1].x - points[0].x, y: points[1].y - points[0].y }
+  const len0 = Math.hypot(v0.x, v0.y)
+  const len1 = Math.hypot(v1.x, v1.y)
+  const scale = len1 / len0
+  const angle = Math.atan2(v1.y, v1.x) - Math.atan2(v0.y, v0.x)
+  return { dx, dy, angle, scale }
+}
+
+export default function TriangleTransform(): React.ReactElement {
+  const [pts, setPts] = useState<Point[]>(initial)
+  const dragIndex = useRef<number | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  function getPos(e: React.PointerEvent<HTMLDivElement>): Point {
+    const rect = containerRef.current!.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  function onDown(idx: number, e: React.PointerEvent<HTMLDivElement>) {
+    e.preventDefault()
+    dragIndex.current = idx
+    ;(e.target as Element).setPointerCapture(e.pointerId)
+  }
+
+  function onMove(e: React.PointerEvent<HTMLDivElement>) {
+    if (dragIndex.current === null) return
+    const pos = getPos(e)
+    setPts(p => p.map((pt, i) => (i === dragIndex.current ? pos : pt)))
+  }
+
+  function onUp(e: React.PointerEvent<HTMLDivElement>) {
+    dragIndex.current = null
+    ;(e.target as Element).releasePointerCapture(e.pointerId)
+  }
+
+  const { dx, dy, angle, scale } = transform(pts)
+  const cos = Math.cos(angle) * scale
+  const sin = Math.sin(angle) * scale
+
+  return (
+    <div ref={containerRef} className="absolute inset-0" onPointerMove={onMove} onPointerUp={onUp}>
+      <svg className="absolute inset-0 h-full w-full" fill="none" stroke="purple" strokeWidth="2">
+        <polygon points={pts.map(p => `${p.x},${p.y}`).join(' ')} fill="rgba(196,167,255,0.5)" />
+      </svg>
+      {pts.map((p, i) => (
+        <div
+          key={i}
+          style={{ left: p.x - 6, top: p.y - 6 }}
+          className="absolute h-3 w-3 rounded-full bg-purple-600 cursor-pointer"
+          onPointerDown={e => onDown(i, e)}
+        />
+      ))}
+      <InfoPanel title="Transform" className="absolute right-2 top-2 w-56 space-y-1 text-sm">
+        <div>Translation: [{dx.toFixed(1)}, {dy.toFixed(1)}]</div>
+        <div>Rotation: {(angle * 180 / Math.PI).toFixed(1)}°</div>
+        <div>Scale: {scale.toFixed(2)}</div>
+        <div className="mt-2 font-mono text-xs">
+          [ {cos.toFixed(2)} , {(-sin).toFixed(2)} , {dx.toFixed(1)} ]<br />
+          [ {sin.toFixed(2)} , {cos.toFixed(2)} , {dy.toFixed(1)} ]<br />
+          [ 0 , 0 , 1 ]
+        </div>
+      </InfoPanel>
+    </div>
+  )
+}

--- a/packages/demos/transformations/index.mdx
+++ b/packages/demos/transformations/index.mdx
@@ -1,0 +1,7 @@
+import TriangleTransform from '../src/transformations'
+
+# Transformations
+
+Drag the triangle's vertices to explore how translation, rotation and scaling change. The matrix updates live as you move the handles.
+
+<TriangleTransform />


### PR DESCRIPTION
## Summary
- create draggable triangle demo showing live translation, rotation and scaling matrices
- add MDX lesson for transformations
- list the new lesson in the home and demo pages

## Testing
- `pnpm test`
- `pnpm e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849cce1635483238672121272962e00