### PR TITLE
Add Trig Explorer lesson

### DIFF
--- a/apps/site/app/demo/trig-explorer/page.tsx
+++ b/apps/site/app/demo/trig-explorer/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+import TrigExplorer from '@madts/demos/trig-explorer'
+import { useProgress } from '@madts/canvas-core'
+
+export default function TrigExplorerPage() {
+  const { markComplete } = useProgress()
+  useEffect(() => {
+    markComplete('trig-explorer')
+  }, [markComplete])
+
+  return (
+    <main className="flex min-h-screen w-screen flex-col items-center gap-4 p-4">
+      <div className="relative h-[80vh] w-full border flex items-center justify-center">
+        <TrigExplorer />
+      </div>
+    </main>
+  )
+}

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -6,6 +6,7 @@ import { useProgress } from "@madts/canvas-core";
 const lessons = [
   { slug: "hello-shapes", title: "Hello Shapes" },
   { slug: "transformations", title: "Transformations" },
+  { slug: "trig-explorer", title: "Trig Explorer" },
 ];
 
 export default function Home() {

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -15,6 +15,10 @@
     "./transformations": {
       "import": "./dist/transformations/index.js",
       "types": "./dist/transformations/index.d.ts"
+    },
+    "./trig-explorer": {
+      "import": "./dist/trig-explorer/index.js",
+      "types": "./dist/trig-explorer/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/demos/src/index.ts
+++ b/packages/demos/src/index.ts
@@ -1,2 +1,3 @@
 export { default as AreaPerimeter } from './area-perimeter';
 export { default as Transformations } from './transformations';
+export { default as TrigExplorer } from './trig-explorer';

--- a/packages/demos/src/trig-explorer/index.tsx
+++ b/packages/demos/src/trig-explorer/index.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import React, { useState, useRef } from 'react'
+import { InfoPanel } from '@madts/ui-kit'
+
+export default function TrigExplorer(): React.ReactElement {
+  const size = 200
+  const r = 80
+  const cx = size / 2
+  const cy = size / 2
+  const [angle, setAngle] = useState(0)
+  const dragging = useRef(false)
+
+  function angleFromEvent(e: React.PointerEvent<SVGSVGElement>): number {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = e.clientX - rect.left - cx
+    const y = e.clientY - rect.top - cy
+    return Math.atan2(-y, x)
+  }
+
+  function onDown(e: React.PointerEvent<SVGCircleElement>): void {
+    dragging.current = true
+    ;(e.target as Element).setPointerCapture(e.pointerId)
+  }
+  function onMove(e: React.PointerEvent<SVGSVGElement>): void {
+    if (!dragging.current) return
+    setAngle(angleFromEvent(e))
+  }
+  function onUp(e: React.PointerEvent<SVGSVGElement>): void {
+    dragging.current = false
+    ;(e.target as Element).releasePointerCapture(e.pointerId)
+  }
+
+  const sin = Math.sin(angle)
+  const cos = Math.cos(angle)
+  const x = cx + r * cos
+  const y = cy - r * sin
+  const bar = 60
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <svg
+        width={size}
+        height={size}
+        onPointerMove={onMove}
+        onPointerUp={onUp}
+        className="touch-none"
+      >
+        <circle cx={cx} cy={cy} r={r} stroke="#94a3b8" strokeWidth="2" fill="none" />
+        <line x1={cx} y1={cy} x2={x} y2={y} stroke="#94a3b8" strokeWidth="2" />
+        <circle
+          cx={x}
+          cy={y}
+          r="6"
+          fill="#0ea5e9"
+          onPointerDown={onDown}
+          className="cursor-pointer"
+        />
+      </svg>
+      <div
+        className="absolute left-[240px] origin-bottom w-6 bg-sky-300 transition-transform duration-200"
+        style={{ height: bar, transform: `scaleY(${sin})` }}
+      />
+      <div
+        className="absolute top-[240px] origin-left bg-orange-300 h-6 transition-transform duration-200"
+        style={{ width: bar, transform: `scaleX(${cos})` }}
+      />
+      <InfoPanel title="Trig" className="absolute right-2 top-2 w-40 space-y-1 text-sm">
+        <div>Angle: {(angle * 180 / Math.PI).toFixed(1)}&deg;</div>
+        <div>sin: {sin.toFixed(2)}</div>
+        <div>cos: {cos.toFixed(2)}</div>
+      </InfoPanel>
+    </div>
+  )
+}

--- a/packages/demos/trig-explorer/index.mdx
+++ b/packages/demos/trig-explorer/index.mdx
@@ -1,0 +1,7 @@
+import TrigExplorer from '../src/trig-explorer'
+
+# Trig Explorer
+
+Drag the point around the unit circle. The bars show the sine (vertical) and cosine (horizontal) values updating live.
+
+<TrigExplorer />


### PR DESCRIPTION
## Summary
- implement new `TrigExplorer` interactive demo
- expose the component from the demos package
- document lesson with MDX narrative
- add Next.js route for the lesson
- list the lesson on the homepage

## Testing
- `pnpm lint` *(fails: couldn't find Airbnb config)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce24bb1883239bcb47fcfff433f9