### PR TITLE
Add Vectors & Dot Product lesson

### DIFF
--- a/apps/site/app/demo/page.tsx
+++ b/apps/site/app/demo/page.tsx
@@ -8,6 +8,7 @@ const lessons = [
   { slug: 'transformations', title: 'Transformations' },
   { slug: 'trig-explorer', title: 'Trig Explorer' },
   { slug: 'conic-sections', title: 'Conic Sections' },
+  { slug: 'vectors-dot-product', title: 'Vectors & Dot Product' },
 ]
 
 export default function DemoList() {

--- a/apps/site/app/demo/vectors-dot-product/page.tsx
+++ b/apps/site/app/demo/vectors-dot-product/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+import VectorsDotDemo from '@madts/demos/vectors-dot-product'
+import { useProgress } from '@madts/canvas-core'
+
+export default function VectorsDotProductPage() {
+  const { markComplete } = useProgress()
+  useEffect(() => {
+    markComplete('vectors-dot-product')
+  }, [markComplete])
+
+  return (
+    <main className="flex min-h-screen w-screen flex-col items-center gap-4 p-4">
+      <div className="relative h-[80vh] w-full border flex items-center justify-center">
+        <VectorsDotDemo />
+      </div>
+    </main>
+  )
+}

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -8,6 +8,7 @@ const lessons = [
   { slug: "transformations", title: "Transformations" },
   { slug: "trig-explorer", title: "Trig Explorer" },
   { slug: "conic-sections", title: "Conic Sections" },
+  { slug: "vectors-dot-product", title: "Vectors & Dot Product" },
 ];
 
 export default function Home() {

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -23,6 +23,10 @@
     "./conic-sections": {
       "import": "./dist/conic-sections/index.js",
       "types": "./dist/conic-sections/index.d.ts"
+    },
+    "./vectors-dot-product": {
+      "import": "./dist/vectors-dot-product/index.js",
+      "types": "./dist/vectors-dot-product/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/demos/src/index.ts
+++ b/packages/demos/src/index.ts
@@ -2,3 +2,4 @@ export { default as AreaPerimeter } from './area-perimeter';
 export { default as Transformations } from './transformations';
 export { default as TrigExplorer } from './trig-explorer';
 export { default as ConicSections } from './conic-sections';
+export { default as VectorsDotProduct } from './vectors-dot-product';

--- a/packages/demos/src/vectors-dot-product/index.tsx
+++ b/packages/demos/src/vectors-dot-product/index.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import React, { useState, useRef } from 'react'
+import { InfoPanel } from '@madts/ui-kit'
+
+type Point = { x: number; y: number }
+
+export default function VectorsDotDemo(): React.ReactElement {
+  const size = 300
+  const center = size / 2
+  const [a, setA] = useState<Point>({ x: 220, y: 120 })
+  const [b, setB] = useState<Point>({ x: 80, y: 200 })
+  const drag = useRef<'a' | 'b' | null>(null)
+
+  function pos(e: React.PointerEvent<SVGSVGElement>): Point {
+    const rect = e.currentTarget.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  function onDown(which: 'a' | 'b', e: React.PointerEvent<SVGCircleElement>): void {
+    drag.current = which
+    ;(e.target as Element).setPointerCapture(e.pointerId)
+  }
+
+  function onMove(e: React.PointerEvent<SVGSVGElement>): void {
+    if (!drag.current) return
+    const p = pos(e)
+    if (drag.current === 'a') setA(p)
+    else setB(p)
+  }
+
+  function onUp(e: React.PointerEvent<SVGSVGElement>): void {
+    drag.current = null
+    ;(e.target as Element).releasePointerCapture(e.pointerId)
+  }
+
+  const va = { x: a.x - center, y: center - a.y }
+  const vb = { x: b.x - center, y: center - b.y }
+  const dot = va.x * vb.x + va.y * vb.y
+  const lenA = Math.hypot(va.x, va.y)
+  const lenB = Math.hypot(vb.x, vb.y)
+  const angle = Math.acos(Math.min(Math.max(dot / (lenA * lenB), -1), 1))
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <svg
+        width={size}
+        height={size}
+        onPointerMove={onMove}
+        onPointerUp={onUp}
+        className="touch-none"
+      >
+        <defs>
+          <marker id="arrow" markerWidth="8" markerHeight="8" refX="5" refY="4" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,8 L8,4 z" fill="currentColor" />
+          </marker>
+        </defs>
+        <line x1={center} y1={0} x2={center} y2={size} stroke="#e2e8f0" />
+        <line x1={0} y1={center} x2={size} y2={center} stroke="#e2e8f0" />
+        <line x1={center} y1={center} x2={a.x} y2={a.y} stroke="#f87171" strokeWidth="3" markerEnd="url(#arrow)" />
+        <line x1={center} y1={center} x2={b.x} y2={b.y} stroke="#60a5fa" strokeWidth="3" markerEnd="url(#arrow)" />
+        <circle cx={a.x} cy={a.y} r="6" fill="#f87171" onPointerDown={e => onDown('a', e)} className="cursor-pointer" />
+        <circle cx={b.x} cy={b.y} r="6" fill="#60a5fa" onPointerDown={e => onDown('b', e)} className="cursor-pointer" />
+      </svg>
+      <InfoPanel title="Vectors" className="absolute right-2 top-2 w-44 space-y-1 text-sm">
+        <div>dot: {dot.toFixed(1)}</div>
+        <div>angle: {(angle * 180 / Math.PI).toFixed(1)}&deg;</div>
+      </InfoPanel>
+    </div>
+  )
+}

--- a/packages/demos/vectors-dot-product/index.mdx
+++ b/packages/demos/vectors-dot-product/index.mdx
@@ -1,0 +1,7 @@
+import VectorsDotDemo from '../src/vectors-dot-product'
+
+# Vectors & Dot Product
+
+Drag each arrow's tip to change the vectors. The info panel shows their dot product and angle in real time.
+
+<VectorsDotDemo />


### PR DESCRIPTION
## Summary
- create `vectors-dot-product` lesson with draggable arrows
- export new lesson from demos package
- wire up demo pages and home page lists

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d5900ec88323848a1cc99c2ea7d3