### PR TITLE
Add badge and streak tracking

### DIFF
--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -1,23 +1,30 @@
-"use client"
+'use client';
 
-import Link from "next/link";
-import { useProgress } from "@madts/canvas-core";
+import Link from 'next/link';
+import { useProgress, useAchievements, SPEED_BADGE } from '@madts/canvas-core';
 
 const lessons = [
-  { slug: "hello-shapes", title: "Hello Shapes" },
-  { slug: "transformations", title: "Transformations" },
-  { slug: "trig-explorer", title: "Trig Explorer" },
-  { slug: "conic-sections", title: "Conic Sections" },
-  { slug: "vectors-dot-product", title: "Vectors & Dot Product" },
+  { slug: 'hello-shapes', title: 'Hello Shapes' },
+  { slug: 'transformations', title: 'Transformations' },
+  { slug: 'trig-explorer', title: 'Trig Explorer' },
+  { slug: 'conic-sections', title: 'Conic Sections' },
+  { slug: 'vectors-dot-product', title: 'Vectors & Dot Product' },
 ];
 
 export default function Home() {
   const { isCompleted } = useProgress();
+  const { badges, streak } = useAchievements();
   return (
     <main className="flex min-h-screen w-screen flex-col items-center gap-4 p-4">
       <h1 className="text-xl font-bold">Lessons</h1>
+      <p data-testid="streak">Current streak: {streak}</p>
+      {badges.includes(SPEED_BADGE) && (
+        <p className="text-sm font-bold text-blue-600">
+          Speed learner badge unlocked!
+        </p>
+      )}
       <ul className="space-y-2">
-        {lessons.map(l => (
+        {lessons.map((l) => (
           <li key={l.slug}>
             <Link href={`/demo/${l.slug}`} className="underline">
               {l.title}

--- a/packages/canvas-core/src/index.ts
+++ b/packages/canvas-core/src/index.ts
@@ -69,3 +69,9 @@ export function polygonPerimeter(points: Point[]): number {
 export { P5Canvas } from './P5Canvas';
 export type { Sketch } from './P5Canvas';
 export { useProgress } from './useProgress';
+export {
+  useAchievements,
+  recordCompletion,
+  type AchievementState,
+  SPEED_BADGE,
+} from './useAchievements';

--- a/packages/canvas-core/src/useAchievements.test.ts
+++ b/packages/canvas-core/src/useAchievements.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import {
+  loadAchievements,
+  recordCompletion,
+  SPEED_BADGE,
+} from './useAchievements';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // simple localStorage mock
+  const store: Record<string, string> = {};
+  global.localStorage = {
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = String(v);
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    clear: () => {
+      for (const k in store) delete store[k];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+  global.localStorage.clear();
+});
+
+describe('badge awarding', () => {
+  it('awards badge after 3 lessons in 24h', () => {
+    vi.setSystemTime(0);
+    recordCompletion('a');
+    vi.setSystemTime(60 * 60 * 1000);
+    recordCompletion('b');
+    vi.setSystemTime(2 * 60 * 60 * 1000);
+    recordCompletion('c');
+    const state = loadAchievements();
+    expect(state.badges).toContain(SPEED_BADGE);
+  });
+});
+
+describe('streaks', () => {
+  it('increments streak on consecutive days', () => {
+    vi.setSystemTime(0);
+    recordCompletion('a');
+    vi.setSystemTime(24 * 60 * 60 * 1000);
+    recordCompletion('b');
+    const state = loadAchievements();
+    expect(state.streak).toBe(2);
+  });
+});

--- a/packages/canvas-core/src/useAchievements.ts
+++ b/packages/canvas-core/src/useAchievements.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'madts-achievements';
+export const SPEED_BADGE = 'three-lessons-24h';
+
+export type Completion = {
+  slug: string;
+  ts: number;
+};
+
+export type AchievementState = {
+  completions: Completion[];
+  badges: string[];
+  streak: number;
+};
+
+const emptyState: AchievementState = {
+  completions: [],
+  badges: [],
+  streak: 0,
+};
+
+export function loadAchievements(): AchievementState {
+  if (typeof localStorage === 'undefined') return { ...emptyState };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...emptyState };
+    const data = JSON.parse(raw);
+    return {
+      completions: Array.isArray(data?.completions) ? data.completions : [],
+      badges: Array.isArray(data?.badges) ? data.badges : [],
+      streak: typeof data?.streak === 'number' ? data.streak : 0,
+    };
+  } catch {
+    return { ...emptyState };
+  }
+}
+
+function saveAchievements(state: AchievementState) {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+}
+
+export function recordCompletion(slug: string) {
+  const state = loadAchievements();
+  const now = Date.now();
+  state.completions.push({ slug, ts: now });
+
+  // recompute streak from completions sorted by time
+  const sorted = [...state.completions].sort((a, b) => a.ts - b.ts);
+  let streak = 1;
+  for (let i = sorted.length - 1; i > 0; i -= 1) {
+    const diffDays = Math.floor((sorted[i].ts - sorted[i - 1].ts) / 86400000);
+    if (diffDays === 1) streak += 1;
+    else if (diffDays > 1) break;
+  }
+  state.streak = streak;
+
+  const dayAgo = now - 86400000;
+  const uniqueSlugs = new Set(
+    state.completions.filter((c) => c.ts >= dayAgo).map((c) => c.slug),
+  );
+  if (uniqueSlugs.size >= 3 && !state.badges.includes(SPEED_BADGE)) {
+    state.badges.push(SPEED_BADGE);
+  }
+
+  saveAchievements(state);
+}
+
+export function useAchievements() {
+  const [state, setState] = useState<AchievementState>(() =>
+    loadAchievements(),
+  );
+
+  const refresh = useCallback(() => setState(loadAchievements()), []);
+
+  useEffect(() => {
+    refresh();
+    if (typeof window !== 'undefined') {
+      const handler = () => refresh();
+      window.addEventListener('storage', handler);
+      return () => window.removeEventListener('storage', handler);
+    }
+    return;
+  }, [refresh]);
+
+  const reset = useCallback(() => {
+    saveAchievements({ ...emptyState });
+    refresh();
+  }, [refresh]);
+
+  return { ...state, reset };
+}

--- a/packages/canvas-core/src/useProgress.ts
+++ b/packages/canvas-core/src/useProgress.ts
@@ -1,48 +1,50 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react';
+import { recordCompletion } from './useAchievements';
 
-const STORAGE_KEY = 'madts-progress'
+const STORAGE_KEY = 'madts-progress';
 
 function load(): string[] {
-  if (typeof window === 'undefined') return []
+  if (typeof window === 'undefined') return [];
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return []
-    const data = JSON.parse(raw)
-    return Array.isArray(data) ? data : []
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    return Array.isArray(data) ? data : [];
   } catch {
-    return []
+    return [];
   }
 }
 
 export function useProgress() {
-  const [completed, setCompleted] = useState<string[]>([])
+  const [completed, setCompleted] = useState<string[]>([]);
 
   useEffect(() => {
-    setCompleted(load())
-  }, [])
+    setCompleted(load());
+  }, []);
 
   const save = useCallback((items: string[]) => {
-    setCompleted(items)
+    setCompleted(items);
     if (typeof window !== 'undefined') {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
     }
-  }, [])
+  }, []);
 
   const markComplete = useCallback(
     (slug: string) => {
-      if (completed.includes(slug)) return
-      const updated = [...completed, slug]
-      save(updated)
+      if (completed.includes(slug)) return;
+      const updated = [...completed, slug];
+      save(updated);
+      recordCompletion(slug);
     },
-    [completed, save]
-  )
+    [completed, save],
+  );
 
   const isCompleted = useCallback(
     (slug: string) => completed.includes(slug),
-    [completed]
-  )
+    [completed],
+  );
 
-  const reset = useCallback(() => save([]), [save])
+  const reset = useCallback(() => save([]), [save]);
 
-  return { completed, markComplete, isCompleted, reset }
+  return { completed, markComplete, isCompleted, reset };
 }


### PR DESCRIPTION
## Summary
- implement `useAchievements` hook to track streaks and badges in localStorage
- trigger badge/streak updates from `useProgress`
- show streak/badge info on home page
- add unit tests for achievements logic

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d6a15f3c8323aac6a6fbc97f10b2