### PR TITLE
Include ui-kit and demos tsconfigs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,12 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
-    project: ['./apps/site/tsconfig.json', './packages/canvas-core/tsconfig.json'],
+    project: [
+      './apps/site/tsconfig.json',
+      './packages/canvas-core/tsconfig.json',
+      './packages/ui-kit/tsconfig.json',
+      './packages/demos/tsconfig.json',
+    ],
   },
   plugins: [
     '@typescript-eslint',


### PR DESCRIPTION
## Summary
- include packages/ui-kit and packages/demos tsconfigs in ESLint config

## Testing
- `pnpm lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.)*

------
https://chatgpt.com/codex/tasks/task_e_684acd3eae70832392bb05c3713d3a20