### PR TITLE
Add build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,16 @@ math-playground/
    cd math-playground
    pnpm install
    ```
-2. **Run locally**
+2. **Build packages**
+   ```bash
+   pnpm build
+   ```
+3. **Run locally**
    ```bash
    pnpm dev   # localhost:3000
    ```
-3. **Open** <http://localhost:3000> and drag out a *Square Builder*—area & perimeter update live.
-4. **Deploy**
+4. **Open** <http://localhost:3000> and drag out a *Square Builder*—area & perimeter update live.
+5. **Deploy**
    * Click the **Vercel** button above and follow the prompts (free tier OK).
    * In your repository settings add `VERCEL_PROJECT_ID` and `VERCEL_ORG_ID` as
      secrets so GitHub Actions can trigger preview and production deployments.

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "typescript": "^5"
   },
   "scripts": {
-      "lint": "ESLINT_USE_FLAT_CONFIG=false pnpm exec eslint \"**/*.{ts,tsx,mdx}\"",
-      "format": "pnpm exec prettier \"**/*.{ts,tsx,mdx}\" --write",
-      "test": "vitest run",
-      "e2e": "playwright test"
+    "lint": "ESLINT_USE_FLAT_CONFIG=false pnpm exec eslint \"**/*.{ts,tsx,mdx}\"",
+    "format": "pnpm exec prettier \"**/*.{ts,tsx,mdx}\" --write",
+    "test": "vitest run",
+    "e2e": "playwright test",
+    "build": "pnpm -r --parallel build"
   }
 }


### PR DESCRIPTION
## Summary
- add a `build` command to build all packages in parallel
- document `pnpm build` in the quick start guide

## Testing
- `pnpm lint` *(fails: ESLint config errors)*
- `pnpm test`
- `pnpm e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684acfba10508323a9708d5b16df00ff